### PR TITLE
Add EntityDetail to FeeDestination 

### DIFF
--- a/src/components/AssetClassification/EntityDetailDisplay.tsx
+++ b/src/components/AssetClassification/EntityDetailDisplay.tsx
@@ -1,0 +1,38 @@
+import { FunctionComponent, useEffect, useState } from "react";
+import { EntityDetail } from "../../models"
+import { InputOrDisplay } from "../Input";
+
+interface EntityDetailProps {
+    detail: EntityDetail,
+    editable: boolean,
+    handleChange: () => any,
+}
+
+const initialState = (entityDetail?: EntityDetail) => ({
+    name: entityDetail?.name || '',
+    description: entityDetail?.description || '',
+    home_url: entityDetail?.home_url || '',
+    source_url: entityDetail?.source_url || '',
+})
+
+export const EntityDetailDisplay: FunctionComponent<EntityDetailProps> = ({ detail, editable, handleChange }) => {
+    const [params, setParams] = useState(initialState(detail));
+
+    useEffect(() => setParams(initialState(detail)), [detail]);
+
+    const updateParam = (key: string, value: string) => {
+        setParams({
+            ...params,
+            [key]: value,
+        });
+        (detail as any)[key] = value;
+        handleChange();
+    };
+
+    return <>
+        <InputOrDisplay label="Name" value={params.name} editable={editable} onChange={(e) => { updateParam('name', e.target.value) }} />
+        <InputOrDisplay label="Description" value={params.description} editable={editable} onChange={(e) => { updateParam('description', e.target.value) }} />
+        <InputOrDisplay label="Home URL" type="url" value={params.home_url} editable={editable} onChange={(e) => { updateParam('home_url', e.target.value) }} />
+        <InputOrDisplay label="Source URL" type="url" value={params.source_url} editable={editable} onChange={(e) => { updateParam('source_url', e.target.value) }} />
+    </>;
+}

--- a/src/components/AssetClassification/FeeDestination.tsx
+++ b/src/components/AssetClassification/FeeDestination.tsx
@@ -12,7 +12,7 @@ const FeeDestinationControlWrapper = styled.div`
 
 const FeeDestinationContentWrapper = styled.div`
     display: grid;
-    grid-template-columns: 1fr 1fr auto;
+    grid-template-columns: 1fr 1fr;
     grid-gap: 10px;
     width: 100%;
     > * {

--- a/src/components/AssetClassification/FeeDestination.tsx
+++ b/src/components/AssetClassification/FeeDestination.tsx
@@ -5,10 +5,12 @@ import { RemoveButton } from "../Button";
 import { InputOrDisplay } from "../Input";
 import { EntityDetailDisplay } from "./EntityDetailDisplay";
 
-const FeeDestinationControlWrapper = styled.div<{ isNotLastElement: boolean }>`
+const FeeDestinationControlWrapper = styled.div`
     display: flex;
     gap: 10px;
-    padding-bottom: ${({ isNotLastElement }) => isNotLastElement && '25px' };
+    &:not(:last-child) {
+        padding-bottom: 25px;
+    }
 `;
 
 const FeeDestinationContentWrapper = styled.div`
@@ -26,12 +28,11 @@ const FeeDestinationContentWrapper = styled.div`
 interface FeeDestinationDetailsProps {
     destination: FeeDestination,
     editable: boolean,
-    isNotLastElement: boolean,
     handleChange: () => any,
     requestRemoval: () => any,
 }
 
-export const FeeDestinationDetails: FunctionComponent<FeeDestinationDetailsProps> = ({ destination, editable, isNotLastElement, handleChange, requestRemoval }) => {
+export const FeeDestinationDetails: FunctionComponent<FeeDestinationDetailsProps> = ({ destination, editable, handleChange, requestRemoval }) => {
     useEffect(() => {
         if (!destination.entity_detail) {
             destination.entity_detail = newEntityDetail();
@@ -53,7 +54,7 @@ export const FeeDestinationDetails: FunctionComponent<FeeDestinationDetailsProps
         handleChange()
     }
 
-    return <FeeDestinationControlWrapper isNotLastElement={isNotLastElement}>
+    return <FeeDestinationControlWrapper>
         {editable && <div><RemoveButton onClick={requestRemoval} /></div>}
         <FeeDestinationContentWrapper>
             <InputOrDisplay label="Address" value={destination.address} editable={editable} onChange={(e) => { updateParam('address', e.target.value) }} />

--- a/src/components/AssetClassification/FeeDestination.tsx
+++ b/src/components/AssetClassification/FeeDestination.tsx
@@ -8,6 +8,7 @@ import { EntityDetailDisplay } from "./EntityDetailDisplay";
 const FeeDestinationControlWrapper = styled.div`
     display: flex;
     gap: 10px;
+    padding-bottom: 25px;
 `;
 
 const FeeDestinationContentWrapper = styled.div`

--- a/src/components/AssetClassification/FeeDestination.tsx
+++ b/src/components/AssetClassification/FeeDestination.tsx
@@ -5,10 +5,16 @@ import { RemoveButton } from "../Button";
 import { InputOrDisplay } from "../Input";
 import { EntityDetailDisplay } from "./EntityDetailDisplay";
 
-const FeeDestinationWrapper = styled.div`
+const FeeDestinationControlWrapper = styled.div`
+    display: flex;
+    gap: 10px;
+`;
+
+const FeeDestinationContentWrapper = styled.div`
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr 1fr auto;
     grid-gap: 10px;
+    width: 100%;
     > * {
         display: flex;
         flex-direction: column;
@@ -45,10 +51,12 @@ export const FeeDestinationDetails: FunctionComponent<FeeDestinationDetailsProps
         handleChange()
     }
 
-    return <FeeDestinationWrapper>
-        <InputOrDisplay label="Address" value={destination.address} editable={editable} onChange={(e) => { updateParam('address', e.target.value) }} />
-        <InputOrDisplay label="Fee Amount" value={destination.fee_amount} editable={editable} onChange={(e) => { updateParam('fee_amount', e.target.value) }} />
-        <EntityDetailDisplay detail={destination.entity_detail as EntityDetail} editable={editable} handleChange={handleChange} />
+    return <FeeDestinationControlWrapper>
         {editable && <div><RemoveButton onClick={requestRemoval} /></div>}
-    </FeeDestinationWrapper>
+        <FeeDestinationContentWrapper>
+            <InputOrDisplay label="Address" value={destination.address} editable={editable} onChange={(e) => { updateParam('address', e.target.value) }} />
+            <InputOrDisplay label="Fee Amount" value={destination.fee_amount} editable={editable} onChange={(e) => { updateParam('fee_amount', e.target.value) }} />
+            <EntityDetailDisplay detail={destination.entity_detail as EntityDetail} editable={editable} handleChange={handleChange} />
+        </FeeDestinationContentWrapper>
+    </FeeDestinationControlWrapper>;
 }

--- a/src/components/AssetClassification/FeeDestination.tsx
+++ b/src/components/AssetClassification/FeeDestination.tsx
@@ -1,12 +1,13 @@
-import { FunctionComponent, useState } from "react";
+import { FunctionComponent, useEffect, useState } from "react";
 import styled from "styled-components";
-import { FeeDestination } from "../../models";
+import { EntityDetail, FeeDestination, newEntityDetail } from "../../models";
 import { RemoveButton } from "../Button";
 import { InputOrDisplay } from "../Input";
+import { EntityDetailDisplay } from "./EntityDetailDisplay";
 
 const FeeDestinationWrapper = styled.div`
     display: grid;
-    grid-template-columns: 1fr 1fr auto;
+    grid-template-columns: 1fr 1fr;
     grid-gap: 10px;
     > * {
         display: flex;
@@ -23,12 +24,19 @@ interface FeeDestinationDetailsProps {
 }
 
 export const FeeDestinationDetails: FunctionComponent<FeeDestinationDetailsProps> = ({ destination, editable, handleChange, requestRemoval }) => {
+    useEffect(() => {
+        if (!destination.entity_detail) {
+            destination.entity_detail = newEntityDetail();
+        }
+    }, [destination])
+
     const [params, setParams] = useState({
         address: destination.address,
-        fee_amount: destination.fee_amount
+        fee_amount: destination.fee_amount,
+        entity_detail: destination.entity_detail,
     })
 
-    const updateParam = (key: string, value: string) => {
+    const updateParam = (key: string, value: any) => {
         setParams({
             ...params,
             [key]: value
@@ -40,6 +48,7 @@ export const FeeDestinationDetails: FunctionComponent<FeeDestinationDetailsProps
     return <FeeDestinationWrapper>
         <InputOrDisplay label="Address" value={destination.address} editable={editable} onChange={(e) => { updateParam('address', e.target.value) }} />
         <InputOrDisplay label="Fee Amount" value={destination.fee_amount} editable={editable} onChange={(e) => { updateParam('fee_amount', e.target.value) }} />
+        <EntityDetailDisplay detail={destination.entity_detail as EntityDetail} editable={editable} handleChange={handleChange} />
         {editable && <div><RemoveButton onClick={requestRemoval} /></div>}
     </FeeDestinationWrapper>
 }

--- a/src/components/AssetClassification/FeeDestination.tsx
+++ b/src/components/AssetClassification/FeeDestination.tsx
@@ -5,10 +5,10 @@ import { RemoveButton } from "../Button";
 import { InputOrDisplay } from "../Input";
 import { EntityDetailDisplay } from "./EntityDetailDisplay";
 
-const FeeDestinationControlWrapper = styled.div`
+const FeeDestinationControlWrapper = styled.div<{ isNotLastElement: boolean }>`
     display: flex;
     gap: 10px;
-    padding-bottom: 25px;
+    padding-bottom: ${({ isNotLastElement }) => isNotLastElement && '25px' };
 `;
 
 const FeeDestinationContentWrapper = styled.div`
@@ -26,11 +26,12 @@ const FeeDestinationContentWrapper = styled.div`
 interface FeeDestinationDetailsProps {
     destination: FeeDestination,
     editable: boolean,
+    isNotLastElement: boolean,
     handleChange: () => any,
     requestRemoval: () => any,
 }
 
-export const FeeDestinationDetails: FunctionComponent<FeeDestinationDetailsProps> = ({ destination, editable, handleChange, requestRemoval }) => {
+export const FeeDestinationDetails: FunctionComponent<FeeDestinationDetailsProps> = ({ destination, editable, isNotLastElement, handleChange, requestRemoval }) => {
     useEffect(() => {
         if (!destination.entity_detail) {
             destination.entity_detail = newEntityDetail();
@@ -52,7 +53,7 @@ export const FeeDestinationDetails: FunctionComponent<FeeDestinationDetailsProps
         handleChange()
     }
 
-    return <FeeDestinationControlWrapper>
+    return <FeeDestinationControlWrapper isNotLastElement={isNotLastElement}>
         {editable && <div><RemoveButton onClick={requestRemoval} /></div>}
         <FeeDestinationContentWrapper>
             <InputOrDisplay label="Address" value={destination.address} editable={editable} onChange={(e) => { updateParam('address', e.target.value) }} />

--- a/src/components/AssetClassification/Verifier.tsx
+++ b/src/components/AssetClassification/Verifier.tsx
@@ -129,7 +129,7 @@ export const AssetVerifier: FunctionComponent<AssetVerifierProps> = ({ asset_typ
         </AssetVerifierDetails>
         <FeeDestinations>
             <H5>Fee Destinations {editable && <AddButton onClick={addFeeDestination} style={{float: "right"}} title="Add Fee Destination" />}</H5>
-            {verifier.fee_destinations.length === 0 ? 'No Fee Destinations' : verifier.fee_destinations.map((destination, index) => <FeeDestinationDetails key={destination.address} destination={destination} editable={editable} isNotLastElement={index !== verifier.fee_destinations.length - 1} handleChange={handleChange} requestRemoval={() => updateParam('fee_destinations', params.fee_destinations.filter(d => d !== destination))} />)}
+            {verifier.fee_destinations.length === 0 ? 'No Fee Destinations' : verifier.fee_destinations.map(destination => <FeeDestinationDetails key={destination.address} destination={destination} editable={editable} handleChange={handleChange} requestRemoval={() => updateParam('fee_destinations', params.fee_destinations.filter(d => d !== destination))} />)}
         </FeeDestinations>
         {!newDefinition && !creating && editable && dirty && !definitionDirty && <ActionContainer><Button onClick={handleUpdate}>Update Verifier</Button></ActionContainer>}
         {!newDefinition && creating && <ActionContainer><Button onClick={handleCreate}>Add Verifier</Button></ActionContainer>}

--- a/src/components/AssetClassification/Verifier.tsx
+++ b/src/components/AssetClassification/Verifier.tsx
@@ -129,7 +129,7 @@ export const AssetVerifier: FunctionComponent<AssetVerifierProps> = ({ asset_typ
         </AssetVerifierDetails>
         <FeeDestinations>
             <H5>Fee Destinations {editable && <AddButton onClick={addFeeDestination} style={{float: "right"}} title="Add Fee Destination" />}</H5>
-            {verifier.fee_destinations.length === 0 ? 'No Fee Destinations' : verifier.fee_destinations.map(destination => <FeeDestinationDetails key={destination.address} destination={destination} editable={editable} handleChange={handleChange} requestRemoval={() => updateParam('fee_destinations', params.fee_destinations.filter(d => d !== destination))} />)}
+            {verifier.fee_destinations.length === 0 ? 'No Fee Destinations' : verifier.fee_destinations.map((destination, index) => <FeeDestinationDetails key={destination.address} destination={destination} editable={editable} isNotLastElement={index !== verifier.fee_destinations.length - 1} handleChange={handleChange} requestRemoval={() => updateParam('fee_destinations', params.fee_destinations.filter(d => d !== destination))} />)}
         </FeeDestinations>
         {!newDefinition && !creating && editable && dirty && !definitionDirty && <ActionContainer><Button onClick={handleUpdate}>Update Verifier</Button></ActionContainer>}
         {!newDefinition && creating && <ActionContainer><Button onClick={handleCreate}>Add Verifier</Button></ActionContainer>}

--- a/src/components/AssetClassification/Verifier.tsx
+++ b/src/components/AssetClassification/Verifier.tsx
@@ -11,6 +11,7 @@ import { InputOrDisplay } from "../Input"
 import { FeeDestinationDetails } from "./FeeDestination"
 import deepEqual from "deep-equal";
 import { useTransaction } from "../../hooks"
+import { EntityDetailDisplay } from "./EntityDetailDisplay"
 
 const AssetVerifierWrapper = styled.div`
     position: relative;
@@ -124,7 +125,7 @@ export const AssetVerifier: FunctionComponent<AssetVerifierProps> = ({ asset_typ
         <AssetVerifierDetails>
             <InputOrDisplay label="Verifier Address" value={params.address} editable={editable} onChange={(e) => { updateParam('address', e.target.value) }} />
             <InputOrDisplay label="Onboarding Cost" value={onboardingCost} editable={editable} onChange={(e) => handleCostChange(e.target.value)} />
-            <AssetVerifierDetail detail={verifier.entity_detail as EntityDetail} editable={editable} handleChange={handleChange} />
+            <EntityDetailDisplay detail={verifier.entity_detail as EntityDetail} editable={editable} handleChange={handleChange} />
         </AssetVerifierDetails>
         <FeeDestinations>
             <H5>Fee Destinations {editable && <AddButton onClick={addFeeDestination} style={{float: "right"}} title="Add Fee Destination" />}</H5>
@@ -133,45 +134,6 @@ export const AssetVerifier: FunctionComponent<AssetVerifierProps> = ({ asset_typ
         {!newDefinition && !creating && editable && dirty && !definitionDirty && <ActionContainer><Button onClick={handleUpdate}>Update Verifier</Button></ActionContainer>}
         {!newDefinition && creating && <ActionContainer><Button onClick={handleCreate}>Add Verifier</Button></ActionContainer>}
     </AssetVerifierWrapper>
-}
-
-interface AssetVerifierDetailProps {
-    detail: EntityDetail,
-    editable: boolean,
-    handleChange: () => any
-}
-
-const initialState = (entityDetail: EntityDetail) => ({
-    name: entityDetail.name,
-    description: entityDetail.description,
-    home_url: entityDetail.home_url,
-    source_url: entityDetail.source_url,
-})
-
-const AssetVerifierDetail: FunctionComponent<AssetVerifierDetailProps> = ({ detail, editable, handleChange }) => {
-
-    const [params, setParams] = useState(initialState(detail))
-
-    useEffect(() => {
-        setParams(initialState(detail))
-
-    }, [detail])
-
-    const updateParam = (key: string, value: string) => {
-        setParams({
-            ...params,
-            [key]: value
-        });
-        (detail as any)[key] = value
-        handleChange()
-    }
-
-    return <>   
-        <InputOrDisplay label="Name" value={params.name} editable={editable} onChange={(e) => { updateParam('name', e.target.value) }} />
-        <InputOrDisplay label="Description" value={params.description} editable={editable} onChange={(e) => updateParam('description', e.target.value)} />
-        <InputOrDisplay label="Home URL" type="url" value={params.home_url} editable={editable} onChange={(e) => { updateParam('home_url', e.target.value) }} />
-        <InputOrDisplay label="Source URL" type="url" value={params.source_url} editable={editable} onChange={(e) => { updateParam('source_url', e.target.value) }} />
-    </>
 }
 
 const FeeDestinations = styled.div`

--- a/src/models/AssetClassificationContract.ts
+++ b/src/models/AssetClassificationContract.ts
@@ -125,6 +125,7 @@ export function newEntityDetail(): EntityDetail {
 export interface FeeDestination {
     address: string,
     fee_amount: string,
+    entity_detail?: EntityDetail,
 }
 
 export interface EntityDetail {


### PR DESCRIPTION
## Description
The contract now supports an optional entity detail on the fee destinations; this change will support that.  Moved and renamed the `AssetVerifierDetail` component from the `Verifier` file to now be a global component for use in both the verifier display as well as the fee destination display.

## Example of new Fee Destination
![Screen Shot 2022-06-02 at 2 41 18 PM](https://user-images.githubusercontent.com/49877044/171743191-5a859c19-2089-4623-bfea-658d489291a7.png)

## Example of multiple fee destinations (includes padding below non-final items)
![Screen Shot 2022-06-02 at 2 56 03 PM](https://user-images.githubusercontent.com/49877044/171745092-d8467919-fe4b-40f2-848c-2c28d55287f8.png)

